### PR TITLE
Update to properly match training instance types to allowed types

### DIFF
--- a/templates/master.template
+++ b/templates/master.template
@@ -217,10 +217,6 @@
         "TrainingInstanceType": {
             "Type": "String",
             "AllowedValues": [
-                "ml.t2.medium",
-                "ml.t2.large",
-                "ml.t2.xlarge",
-                "ml.t2.2xlarge",
                 "ml.m5.large",
                 "ml.m5.xlarge",
                 "ml.m5.2xlarge",
@@ -250,7 +246,7 @@
                 "ml.p2.16xlarge"
             ],
             "Description": "The instance type to train the SageMaker model with.  Check the documentation for your chosen algorithm for instance type recommendations.",
-            "Default": "ml.t2.medium"
+            "Default": "ml.m5.large"
         },
         "NotebookInstanceType": {
             "Type": "String",


### PR DESCRIPTION
Valid types are: ml.m4.xlarge | ml.m4.2xlarge | ml.m4.4xlarge | ml.m4.10xlarge | ml.m4.16xlarge | ml.m5.large | ml.m5.xlarge | ml.m5.2xlarge | ml.m5.4xlarge | ml.m5.12xlarge | ml.m5.24xlarge | ml.c4.xlarge | ml.c4.2xlarge | ml.c4.4xlarge | ml.c4.8xlarge | ml.p2.xlarge | ml.p2.8xlarge | ml.p2.16xlarge | ml.p3.2xlarge | ml.p3.8xlarge | ml.p3.16xlarge | ml.c5.xlarge | ml.c5.2xlarge | ml.c5.4xlarge | ml.c5.9xlarge | ml.c5.18xlarge according to https://docs.aws.amazon.com/sagemaker/latest/dg/API_ResourceConfig.html.

In the prior version, the instance types were pulled from the valid instances for scoring endpoints