### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/templates/deliver.template
+++ b/templates/deliver.template
@@ -200,7 +200,7 @@
                         "Fn::Sub": "${LambdaCodeS3KeyPrefix}${DeliverApiLambdaCodeLocation}"
                     }
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": 30,
                 "Environment": {
                     "Variables": {
@@ -228,7 +228,7 @@
                         "Fn::Sub": "${LambdaCodeS3KeyPrefix}${PredictApiLambdaCodeLocation}"
                     }
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": 30,
                 "Environment": {
                     "Variables": {

--- a/templates/imet.template
+++ b/templates/imet.template
@@ -482,7 +482,7 @@
                         "Fn::Sub": "${LambdaCodeS3KeyPrefix}${IngestLambdaCodeLocation}"
                     }
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": 90,
                 "MemorySize": "1024",
                 "Environment": {
@@ -510,7 +510,7 @@
                         "Fn::Sub": "${LambdaCodeS3KeyPrefix}${ModelLambdaCodeLocation}"
                     }
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": 90,
                 "MemorySize": "2048",
                 "Environment": {
@@ -541,7 +541,7 @@
                         "Fn::Sub": "${LambdaCodeS3KeyPrefix}${EnhanceLambdaCodeLocation}"
                     }
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": 30,
                 "MemorySize": "1024",
                 "Environment": {
@@ -572,7 +572,7 @@
                         "Fn::Sub": "${LambdaCodeS3KeyPrefix}${TransformLambdaCodeLocation}"
                     }
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": 30,
                 "MemorySize": "1024",
                 "Environment": {

--- a/templates/sagemaker.template
+++ b/templates/sagemaker.template
@@ -901,7 +901,7 @@
                         "Fn::Sub": "${LambdaCodeS3KeyPrefix}${SageMakerDataPrepLambdaCodeLocation}"
                     }
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": 300,
                 "MemorySize": 1024,
                 "Environment": {
@@ -941,7 +941,7 @@
                         "Fn::Sub": "${LambdaCodeS3KeyPrefix}${SageMakerTrainingKickoffLambdaCodeLocation}"
                     }
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": 300,
                 "Environment": {
                     "Variables": {
@@ -997,7 +997,7 @@
                         "Fn::Sub": "${LambdaCodeS3KeyPrefix}${SageMakerEndpointUpdateLambdaCodeLocation}"
                     }
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": 300,
                 "Environment": {
                     "Variables": {


### PR DESCRIPTION
CloudFormation templates in quickstart-datalake-pariveda have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.